### PR TITLE
update twitter account link as currently 404

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Make sure all of your commits are atomic (one feature per commit).
 Always write a clear log message for your commits.
 
 If you submit a pull request, we will love you forever ! 
-And if you don't, at least send us a feedback on Twitter @OktyOfficial sharing your experience with Okty.
+And if you don't, at least send us a feedback on Twitter @OktyApp sharing your experience with Okty.
 
 ## Coding conventions
 

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -50,7 +50,7 @@
                            uk-icon="github"></a>
                     </li>
                     <li>
-                         <a href="https://twitter.com/oktyofficial" class="uk-icon-link okty-navbar-text" target="_blank" uk-icon="twitter"></a>
+                         <a href="https://twitter.com/OktyApp" class="uk-icon-link okty-navbar-text" target="_blank" uk-icon="twitter"></a>
                     </li>
                 </ul>
 

--- a/src/app/components/review/review.component.html
+++ b/src/app/components/review/review.component.html
@@ -16,7 +16,7 @@
         <p>
             We strongly recommend you to NOT use this in a Production Environment since we're still on Beta Version.
             <br>
-            Follow us on Twitter <a href="https://twitter.com/OktyOfficial" target="blank">@OktyOfficial</a> to keep
+            Follow us on Twitter <a href="https://twitter.com/OktyApp" target="blank">@OktyApp</a> to keep
             yourself
             up to date
         </p>


### PR DESCRIPTION
# Description

Just update Twitter links as current links are 404. Assuming you change OktyOfficial to OktyApp.