### PR TITLE
[WIP] Fix select element + sidebar tooltip ; allow docker image customization

### DIFF
--- a/src/app/components/setup/form/select/select.component.html
+++ b/src/app/components/setup/form/select/select.component.html
@@ -6,7 +6,9 @@
         (focus)="showSelect()"
         (focusout)="hideSelect()"
         [id]="input.id"
-        [ngClass]="{'errors':formControl.invalid}">
+        [ngClass]="{'errors':formControl.invalid}"
+        class="uk-input"
+        autocomplete="off">
     <p *ngIf="formControl.invalid" class="errors">{{ formControl.errors | validatorErrors }}</p>
 
     <ul class='select' [ngClass]="{'show': show }">

--- a/src/app/components/setup/form/select/select.component.scss
+++ b/src/app/components/setup/form/select/select.component.scss
@@ -29,13 +29,11 @@
         cursor: pointer;
 
         &[type="text"] {
-            background: none;
             outline: none;
             border: none;
             border-bottom: solid 1px rgba(255, 255, 255, 0.20);
             transition: border-bottom-color ease 0.3s, background-color ease 0.3s;
             padding: 0 10px;
-            color: #ffffff;
 
             &:focus {
                 background-color: rgba(255, 255, 255, 0.15);

--- a/src/app/components/setup/form/select/select.component.ts
+++ b/src/app/components/setup/form/select/select.component.ts
@@ -25,6 +25,9 @@ export class SelectComponent implements OnInit {
 
             this.data.push({value: value, label: this.input.source[value]});
         }
+        if (this.formControl.value && Object.keys(this.input.source).includes(this.formControl.value)) {
+            this.selected = this.formControl.value;
+        }
     }
 
     changeSelected(value: any) {

--- a/src/app/components/sidebar/sidebar.component.html
+++ b/src/app/components/sidebar/sidebar.component.html
@@ -4,7 +4,7 @@
             <span class="uk-icon uk-position-center" uk-icon="plus"></span>
         </li>
         <li *ngFor="let container of containers; let id = index" [routerLink]="'/edit/' + id"
-            class="uk-nav-header okty-container-card" uk-tooltip="title: container.name; pos: right">
+            class="uk-nav-header okty-container-card" attr.uk-tooltip="title: {{container.name}}; pos: right">
             <img class="sidebar-img" [src]="container.image"/>
         </li>
     </ul>

--- a/src/app/services/container.service.ts
+++ b/src/app/services/container.service.ts
@@ -8,7 +8,9 @@ export class ContainerService {
   containerId: any;
 
   public dataToContainer(container: Container, data: any): Container {
-    this.outputConfig = {};
+    this.outputConfig = {
+      'image': container.docker + ':' + container.version
+    };
 
     container.config.forEach((group) => {
       group.fields.forEach((input) => {
@@ -35,8 +37,6 @@ export class ContainerService {
         }
       });
     });
-
-    this.outputConfig['image'] = container.docker + ':' + container.version;
 
     container.output = this.outputConfig;
     container.containerId = this.containerId;


### PR DESCRIPTION
# Description

- Select inputs didn't look like other inputs.
- When creating/editing a container configuration, previous/default value wasn't binding to the select element.
- Sidebar tooltip always displayed "container.name" instead of the container name
- In order to avoid a container configuration template for each version of a system, i made it customizable

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds a functionality)

# Which area/features are impacted ?

### UI
- Sidebar will display the container name as a tooltip
- Select element will look like other kind of elements
### Core
- Default/edited value of a select element will be initially bind to it
- A container configuration can override the image/version of a docker image

# How can we manually test it ?

Please describe the steps for us to check your changes.
Please also list any relevant details for your tests
1. Create a container configuration
2. Add an input with the following configuration:
    -  id: image 
    - label: "Version"
    - type: select
    - source: 
          "node:latest": "latest"
          "node:10": "10"
          "node:8": "8"
          "node:alpine": "alpine"
          "node:10-alpine": "10-alpine"
          "node:8-alpine": "8-alpine"
     - base: image
     - destination: docker-compose
     - value: node:latest
3. Create a new container with the previously mentioned configuration (see the updated select input)
4. Export project and unzip it (see the overridden image field)

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have written my code in a way that it's self descriptive
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings and may be built with production flag without error
- [X] I removed all unused comments or code
